### PR TITLE
Fix 1236861 page categories empty options in virtual rules config when localized catalogs is selected

### DIFF
--- a/packages/components/src/hooks/useSingletonLoader.ts
+++ b/packages/components/src/hooks/useSingletonLoader.ts
@@ -13,6 +13,7 @@ import {
 } from '@elastic-suite/gally-admin-shared'
 
 import { useApiFetch } from './useApi'
+import { useLog } from './useLog'
 
 export type ILoader<T> = (fetchApi: IFetchApi) => Promise<T>
 
@@ -31,7 +32,7 @@ export function useSingletonLoader<T>(
   const fetchApi = useApiFetch()
   const [map, setMap] = useState<Map<string, T>>(defaultState)
   const fieldOptionsStatuses = useRef<ILoadStatuses>(new Map())
-
+  const log = useLog()
   const updateFieldOptions = useCallback((id: string, options: T) => {
     fieldOptionsStatuses.current.set(id, LoadStatus.SUCCEEDED)
     setMap((prevState) => {
@@ -49,12 +50,13 @@ export function useSingletonLoader<T>(
         try {
           const data = await loader(fetchApi)
           updateFieldOptions(id, data)
-        } catch {
+        } catch (err) {
+          log(err)
           fieldOptionsStatuses.current.set(id, LoadStatus.FAILED)
         }
       }
     },
-    [fetchApi, updateFieldOptions]
+    [fetchApi, updateFieldOptions, log]
   )
 
   return { fetch, map, setMap, statuses: fieldOptionsStatuses }

--- a/packages/shared/src/mocks/static/source_field_options.json
+++ b/packages/shared/src/mocks/static/source_field_options.json
@@ -15,7 +15,7 @@
         {
           "@id": "/source_field_option_labels/3439",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -26,7 +26,7 @@
         {
           "@id": "/source_field_option_labels/3452",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -48,7 +48,7 @@
         {
           "@id": "/source_field_option_labels/3440",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -59,7 +59,7 @@
         {
           "@id": "/source_field_option_labels/3453",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -81,7 +81,7 @@
         {
           "@id": "/source_field_option_labels/3441",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -92,7 +92,7 @@
         {
           "@id": "/source_field_option_labels/3454",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -114,7 +114,7 @@
         {
           "@id": "/source_field_option_labels/3442",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -125,7 +125,7 @@
         {
           "@id": "/source_field_option_labels/3455",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -147,7 +147,7 @@
         {
           "@id": "/source_field_option_labels/3456",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -158,7 +158,7 @@
         {
           "@id": "/source_field_option_labels/3443",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -180,7 +180,7 @@
         {
           "@id": "/source_field_option_labels/3457",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -191,7 +191,7 @@
         {
           "@id": "/source_field_option_labels/3444",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -213,7 +213,7 @@
         {
           "@id": "/source_field_option_labels/3445",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -224,7 +224,7 @@
         {
           "@id": "/source_field_option_labels/3458",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -246,7 +246,7 @@
         {
           "@id": "/source_field_option_labels/3446",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -257,7 +257,7 @@
         {
           "@id": "/source_field_option_labels/3459",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -279,7 +279,7 @@
         {
           "@id": "/source_field_option_labels/3447",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -290,7 +290,7 @@
         {
           "@id": "/source_field_option_labels/3460",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -312,7 +312,7 @@
         {
           "@id": "/source_field_option_labels/3461",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -323,7 +323,7 @@
         {
           "@id": "/source_field_option_labels/3448",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -345,7 +345,7 @@
         {
           "@id": "/source_field_option_labels/3462",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -356,7 +356,7 @@
         {
           "@id": "/source_field_option_labels/3449",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -378,7 +378,7 @@
         {
           "@id": "/source_field_option_labels/3450",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,
@@ -389,7 +389,7 @@
         {
           "@id": "/source_field_option_labels/3463",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -411,7 +411,7 @@
         {
           "@id": "/source_field_option_labels/3464",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/49",
             "@type": "LocalizedCatalog",
             "id": 49,
@@ -422,7 +422,7 @@
         {
           "@id": "/source_field_option_labels/3451",
           "@type": "SourceFieldOptionLabel",
-          "catalog": {
+          "localizedCatalog": {
             "@id": "/localized_catalogs/50",
             "@type": "LocalizedCatalog",
             "id": 50,

--- a/packages/shared/src/services/hydra.ts
+++ b/packages/shared/src/services/hydra.ts
@@ -114,8 +114,9 @@ export function getOptionsFromOptionResource(
     let label = option.defaultLabel
     if (localizedCatalogId !== -1) {
       label =
-        option.labels.find((label) => label.catalog.id === localizedCatalogId)
-          ?.label ?? label
+        option.labels.find(
+          (label) => label.localizedCatalog.id === localizedCatalogId
+        )?.label ?? label
     }
     return {
       id: option.code,

--- a/packages/shared/src/types/hydra.ts
+++ b/packages/shared/src/types/hydra.ts
@@ -162,7 +162,7 @@ export interface IHydraMember extends IJsonldBase {
 }
 
 export interface IHydraLabelMember extends IHydraMember {
-  catalog: IHydraSimpleCatalog
+  localizedCatalog: IHydraSimpleCatalog
   label: string
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / current stable version branch for bug fixes
| Tickets       | #... <!-- please link related issues if existing -->
| License       | OSL-3.0
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
