### PR TITLE
fix: #1246612 Height of resourceForm was bug cause to zIndex title

### DIFF
--- a/packages/components/src/components/stateful-pages/ResourceForm/ResourceForm.tsx
+++ b/packages/components/src/components/stateful-pages/ResourceForm/ResourceForm.tsx
@@ -22,11 +22,11 @@ import {
 } from '@elastic-suite/gally-admin-shared'
 import { closeSnackbar, enqueueSnackbar } from 'notistack'
 import { useTranslation } from 'next-i18next'
-import styled from '@emotion/styled'
 import { Box, Theme } from '@mui/material'
 import { useRouter } from 'next/router'
 import PageTitle from '../../atoms/PageTitle/PageTitle'
 import PopIn from '../../atoms/modals/PopIn'
+import { styled } from '@mui/system'
 
 const CustomDoubleButtonSticky = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -44,6 +44,12 @@ interface IProps {
   resourceName: string
   title?: string
 }
+
+const CustomRoot = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(2),
+  flexDirection: 'column',
+}))
 
 function ResourceForm(props: IProps): JSX.Element {
   const { resourceName, id, title } = props
@@ -175,7 +181,7 @@ function ResourceForm(props: IProps): JSX.Element {
   }
 
   return (
-    <>
+    <CustomRoot>
       {title ? (
         <PageTitle title={title} sx={{ marginBottom: '32px' }} sticky>
           <CustomDoubleButtonSticky>
@@ -223,7 +229,7 @@ function ResourceForm(props: IProps): JSX.Element {
         resource={resource}
         errors={errors}
       />
-    </>
+    </CustomRoot>
   )
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / current stable version branch for bug fixes
| Tickets       | #... <!-- please link related issues if existing -->
| License       | OSL-3.0
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
