### PR TITLE
fix: #1191270 display message when thesaurus grid is empty

### DIFF
--- a/packages/components/public/locales/en/resourceTable.json
+++ b/packages/components/public/locales/en/resourceTable.json
@@ -5,6 +5,8 @@
   "facets.none.btn": "Add filterable attributes",
   "boost.none": "No boost has been created",
   "boost.none.btn": "Create a boost",
+  "thesaurus.none": "No thesaurus has been created",
+  "thesaurus.none.btn": "Create a thesarus",
   "default.customValue_zero": "You don't have any custom value",
   "default.customValue_one": "You are using {{value}} custom value",
   "default.customValue_other": "You are using {{value}} custom values",

--- a/packages/components/public/locales/fr/resourceTable.json
+++ b/packages/components/public/locales/fr/resourceTable.json
@@ -5,6 +5,8 @@
   "facets.none.btn": "Ajouter des attributs filtrables",
   "boost.none": "Aucun boost n'a été créé",
   "boost.none.btn": "Créer un boost",
+  "thesaurus.none": "Aucun thésaurus n'a été créé",
+  "thesaurus.none.btn": "Créer un thésaurus",
   "default.customValue_zero": "Vous n'avez pas de valeur personnalisée",
   "default.customValue_one": "Vous utilisez {{value}} valeur personnalisée",
   "default.customValue_other": "Vous utilisez {{value}} valeurs personnalisées",

--- a/packages/components/src/components/stateful-pages/ResourceTable/ResourceTable.tsx
+++ b/packages/components/src/components/stateful-pages/ResourceTable/ResourceTable.tsx
@@ -70,6 +70,13 @@ function getProps(resourceName: string, t: TFunction): INoAttributesProps {
         btnHref: './create',
         absolutLink: false,
       }
+    case 'Thesaurus':
+      return {
+        title: t('thesaurus.none'),
+        btnTitle: t('thesaurus.none.btn'),
+        btnHref: './create',
+        absolutLink: false,
+      }
   }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / current stable version branch for bug fixes
| Tickets       | #... <!-- please link related issues if existing -->
| License       | OSL-3.0
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
